### PR TITLE
Add error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ server.use(async (ctx, next) => {
 })
 ```
 
-#### Call order
+#### Call cascading
 
 All middlewares are executed in order they were registered, followed by an execution of handlers is provided order, regardless of middleware-service order. Not that in the following example, `C` middleware is registered after `CatService` and it is still called, even before the handlers.
 
@@ -130,12 +130,77 @@ server.use(async (ctx, next) => {
 // A2            (middleware)
 ```
 
+## Error handling
+
+### Simple handler
+
+Error handling can be solved with a custom simple middleware, thanks to existing `next` cascading mechanism:
+
+```typescript
+server.use(async (ctx, next) => {
+  try {
+    await next()
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+})
+```
+
+The `next` call contains a complete call stack from the following middlewares/handlers only, that is why it is recommended to use your error-handling middleware as one of the firsts.
+
+### Advanced handler
+
+The simple handler is a perfectly valid option for the synchronous (or asynchronous, "linear") code: like unary calls. In that scenario, you don't need more than that. When working with streams however, the situation is more complicated. When an error is emitted on a stream, it "cannot" be caught and re-thrown, since there could be several listeners on the emitter, which are already responding to that event.
+
+There is an `onError` middleware creator, that can intercept all errors including the stream errors. It can be used not only to log the errors (and pass them on), but also to consume the errors (and not propagate them to the client), rethrow them, or change them.
+
+```typescript
+import { onError } from 'protocat'
+
+server.use(
+  onError((e, ctx) => {
+    // Set metadata
+    ctx.initialMetadata.set('error-code', e.code)
+    ctx.trailingMetadata.set('error-code', e.code)
+
+    // Consume the error
+    if (notThatBad(e)) {
+      if (ctx.type === CallType.SERVER_STREAM || ctx.type === CallType.BIDI) {
+        // sync error not re-thrown on stream response, should end
+        ctx.end()
+      }
+      return
+    }
+
+    // Throw an error
+    if (!expected(e)) {
+      e.message = 'Server error'
+    }
+    throw e
+  })
+)
+```
+
+- The handler is called with error and context for all errors (rejects from handlers, error emits from streams), meaning there can be theoretically more errors per request (multiple emitted errors) and some of them can be handled even after the executon of the next chain (error emits).
+- Provided function can be sync on async. It can throw (or return rejected promise), but any other return value is ignored
+- Both initial and trailing metadata are available for change (unless you sent them manually)
+- In order to achieve "re-throwing", `emit` function on call is patched by `onError`. When calling `call.emit('error', e)`, the error is actually emitted in the stream only when the handler throws a new error. This means that when you emit an error in the middleware and consume it in the handler, streams are left "hanging", not errored and likely not even ended. If you truly wish to not propagate the error to client, it is recommended to end the streams in the handler. (This is not performed automatically, since there is no guarantee there should be no more than one error)
+
+### Details
+
 ## Roadmap
 
 - [x] Middleware
-- [ ] Error handling
+- [x] Error handling
 - [ ] Type safety
 
+- [ ] call / context terminology
+- [ ] call / stream terminology
+- [ ] metaS / metaP test naming confusion
+- [ ] metadata readme section
+- [ ] starter project
+- [ ] gRPC client
 - [ ] Call pool
 - [ ] Context type extension
 - [ ] Partial definition

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export { Server } from './lib/server'
 export { CallType } from './lib/call-types'
+export { onError } from './lib/middleware/on-error'
+export { Middleware } from './lib/context'

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -48,7 +48,7 @@ export type ServiceHandlerBidi<Req, Res> = (
   next: NextFn
 ) => any
 
-type AnyContext =
+export type AnyContext =
   | (ProtoCatContext<Message, Message, CallType.UNARY> &
       grpc.ServerUnaryCall<Message, Message>)
   | (ProtoCatContext<Message, Message, CallType.SERVER_STREAM> &

--- a/src/lib/middleware/on-error.ts
+++ b/src/lib/middleware/on-error.ts
@@ -1,0 +1,53 @@
+import { Middleware, AnyContext } from '../context'
+import { CallType } from '../call-types'
+
+type ErrorHandler = (error: Error, context: AnyContext) => any
+
+/**
+ * Patches emit function to intercept errors with a handler to be able to consume or map dispatched errors on stream, before existing listeners are invoked.
+ * Error events are passed on the handler and metadata are passed on re-thrown errors.
+ * @param emitter gRPC call
+ * @param handler Error handler that can either throw an error, that will be passed on or not throw, in which case cascade is stopped and call does not end with error
+ */
+const mapError = (emitter: any, handler: ErrorHandler) => {
+  const originalEmit = emitter.emit
+  const addMeta = (e: any) => {
+    // Trailing metadata on error calls are taken from `error.metadata`, we pass on the existing trailing metadata
+    // TODO: At this point existing metadata on error is lost
+    e.metadata = emitter.trailingMetadata
+    return e
+  }
+  emitter.emit = async (...args: any[]) => {
+    if (args[0] !== 'error') {
+      return originalEmit.apply(emitter, args)
+    }
+    try {
+      await handler(args[1], emitter)
+    } catch (e) {
+      originalEmit.apply(emitter, ['error', addMeta(e)])
+    }
+  }
+}
+
+/**
+ * onError creates a Protocat middleware that can be used to intercept errors from various origins, either from:
+ *  - sync throws (or async rejects) from following middlewares (or handlers) in the call stack (chain of next functions)
+ *  - error emits on streamed calls
+ */
+export const onError = (handler: ErrorHandler): Middleware => async (
+  call,
+  next
+) => {
+  if (
+    call.type === CallType.SERVER_STREAM ||
+    call.type === CallType.BIDI ||
+    call.type === CallType.CLIENT_STREAM
+  ) {
+    mapError(call, handler)
+  }
+  try {
+    await next()
+  } catch (e) {
+    await handler(e, call)
+  }
+}

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -73,18 +73,18 @@ const wrapToHandler = (
   methodDefinition: grpc.MethodDefinition<any, any>,
   methodHandler: any
 ) => {
-  const initialMetadata = new grpc.Metadata()
-  const trailingMetadata = new grpc.Metadata()
   const type = stubToType(methodDefinition)
-
-  const createContext = (call: any): any =>
-    Object.assign(call, {
+  const createContext = (call: any): any => {
+    const initialMetadata = new grpc.Metadata()
+    const trailingMetadata = new grpc.Metadata()
+    return Object.assign(call, {
       trailingMetadata,
       initialMetadata,
       path: methodDefinition.path,
       flushInitialMetadata: () => call.sendMetadata(initialMetadata),
       type,
     })
+  }
 
   return async (
     call: any, // grpc.ServerReadableStream<any, any> | grpc.ServerUnaryCall<any, any> | grpc.ServerDuplexStream<any, any> | grpc.ServerWritableStream<any, any>

--- a/src/test/on-error.test.ts
+++ b/src/test/on-error.test.ts
@@ -1,0 +1,280 @@
+import { Server, onError, CallType } from '..'
+import {
+  GreetingService,
+  GreetingClient,
+} from '../../dist/test/api/v1/hello_grpc_pb'
+import {
+  ServerCredentials,
+  ChannelCredentials,
+  Metadata,
+  StatusObject,
+} from '@grpc/grpc-js'
+import { Hello } from '../../dist/test/api/v1/hello_pb'
+
+const ADDR = '0.0.0.0:3000'
+describe('Error handling', () => {
+  const server = new Server()
+  let lastError: any = null
+  afterAll(() => server.stop())
+  test('Setup', async () => {
+    server.addService(GreetingService, {
+      unary: ctx => {
+        throw new Error('unary-error')
+      },
+      serverStream: ctx => {
+        if (ctx.metadata.getMap().type === 'sync') {
+          throw new Error('serverStream-sync-error')
+        } else {
+          ctx.emit('error', new Error('serverStream-stream-error'))
+        }
+      },
+      clientStream: ctx => {
+        if (ctx.metadata.getMap().type === 'sync') {
+          throw new Error('clientStream-sync-error')
+        } else {
+          ctx.emit('error', new Error('clientStream-stream-error'))
+        }
+      },
+      bidi: ctx => {
+        if (ctx.metadata.getMap().type === 'sync') {
+          throw new Error('bidi-sync-error')
+        } else {
+          ctx.emit('error', new Error('bidi-stream-error'))
+        }
+      },
+    })
+    server.use(
+      onError((e, ctx) => {
+        ctx.initialMetadata.set('onerror', `${ctx.type}-onerror`)
+        ctx.trailingMetadata.set('onerror', `${ctx.type}-onerror`)
+        if (ctx.metadata.getMap().catch) {
+          lastError = e
+          if (
+            ctx.type === CallType.SERVER_STREAM ||
+            ctx.type === CallType.BIDI
+          ) {
+            // sync error not re-thrown on stream response, should end
+            ctx.end()
+          }
+        } else {
+          // Handler can be sync or async
+          if (Math.random() > 0.5) {
+            throw e
+          }
+          return Promise.reject(e)
+        }
+      })
+    )
+    server.use((ctx, next) => {
+      ctx.initialMetadata.set('initial', ctx.type)
+      ctx.trailingMetadata.set('trailing', `${ctx.type}-trailing`)
+    })
+    await server.start(ADDR, ServerCredentials.createInsecure())
+  })
+  describe('Unary', () => {
+    const client = new GreetingClient(ADDR, ChannelCredentials.createInsecure())
+
+    const clientMeta = new Metadata()
+    clientMeta.set('catch', 'true')
+    test('Caught error does not reach client', async () => {
+      await new Promise<Hello>((resolve, reject) => {
+        client.unary(new Hello(), clientMeta, (err, res) =>
+          err ? reject(err) : resolve(res)
+        )
+      })
+      expect(lastError.message).toMatch(/unary-error/)
+    })
+    describe('Pass through rejects at client with correct status', () => {
+      let metaS: Promise<StatusObject> = null as any
+      let metaP: Promise<Metadata> = null as any
+      test('Throws', async () => {
+        await expect(
+          new Promise<Hello>((resolve, reject) => {
+            const call = client.unary(new Hello(), (err, res) =>
+              err ? reject(err) : resolve(res)
+            )
+            metaS = new Promise(resolve => call.on('status', resolve))
+            metaP = new Promise(resolve => call.on('metadata', resolve))
+          })
+        ).rejects.toThrow(/unary-error/)
+      })
+      test('Error data', async () => {
+        expect((await metaS).code).toBe(2)
+        expect((await metaS).details).toBe('unary-error')
+      })
+      test('Trailing (status) metadata', async () => {
+        expect((await metaS).metadata.getMap().trailing).toBe('unary-trailing')
+        expect((await metaS).metadata.getMap().onerror).toBe('unary-onerror')
+      })
+      test('Initial metadata', async () => {
+        expect((await metaP).getMap().initial).toEqual('unary')
+        expect((await metaP).getMap().onerror).toEqual('unary-onerror')
+      })
+    })
+  })
+  for (const type of ['sync', 'stream']) {
+    describe(`ServerStream (${type} error)`, () => {
+      const client = new GreetingClient(
+        ADDR,
+        ChannelCredentials.createInsecure()
+      )
+      test('Caught error does not reach client', async () => {
+        const clientMeta = new Metadata()
+        clientMeta.set('catch', 'true')
+        clientMeta.set('type', type)
+        await new Promise<Hello>((resolve, reject) => {
+          const stream = client.serverStream(new Hello(), clientMeta)
+          stream.on('data', hello => hello)
+          stream.on('end', () => resolve())
+          stream.on('error', (e: any) => (e.code === 1 ? resolve() : reject(e)))
+        })
+        expect(lastError.message).toMatch(
+          new RegExp(`serverStream-${type}-error`)
+        )
+      })
+      describe('Pass through rejects at client with correct status', () => {
+        const clientMeta = new Metadata()
+        clientMeta.set('type', type)
+        let status: StatusObject = null as any
+        let metaP: Promise<Metadata> = null as any
+
+        test('Throws', async () => {
+          await expect(
+            new Promise<Hello>((resolve, reject) => {
+              const stream = client.serverStream(new Hello(), clientMeta)
+              stream.on('end', () => resolve())
+              metaP = new Promise(resolve => stream.on('metadata', resolve))
+
+              // Does not emit `status`: status object is in error on failure
+              stream.on('error', e => {
+                status = e as any
+                reject(e)
+              })
+            })
+          ).rejects.toThrow(`serverStream-${type}-error`)
+        })
+        test('Error data', () => {
+          expect(status.code).toBe(2)
+          expect(status.details).toBe(`serverStream-${type}-error`)
+        })
+        test('Trailing (status) metadata', () => {
+          expect(status.metadata.getMap().trailing).toBe(
+            'serverStream-trailing'
+          )
+          expect(status.metadata.getMap().onerror).toBe('serverStream-onerror')
+        })
+        test('Initial metadata', async () => {
+          expect((await metaP).getMap().initial).toEqual('serverStream')
+          expect((await metaP).getMap().onerror).toEqual('serverStream-onerror')
+        })
+      })
+    })
+  }
+  for (const type of ['sync', 'stream']) {
+    describe(`ClientStream (${type} error)`, () => {
+      const client = new GreetingClient(
+        ADDR,
+        ChannelCredentials.createInsecure()
+      )
+      test('Caught error does not reach client', async () => {
+        const clientMeta = new Metadata()
+        clientMeta.set('catch', 'true')
+        clientMeta.set('type', type)
+        await new Promise<Hello>((resolve, reject) => {
+          client.clientStream(clientMeta, (err, res) =>
+            err ? reject(err) : resolve(res)
+          )
+        })
+        expect(lastError.message).toMatch(
+          new RegExp(`clientStream-${type}-error`)
+        )
+      })
+      describe('Pass through rejects at client with correct status', () => {
+        const clientMeta = new Metadata()
+        clientMeta.set('type', type)
+        let metaP: Promise<Metadata> = null as any
+        let status: StatusObject = null as any
+        test('Throws', async () => {
+          await expect(
+            new Promise<Hello>((resolve, reject) => {
+              const call = client.clientStream(clientMeta, (err, res) => {
+                if (err) {
+                  status = err
+                  reject(err)
+                }
+                resolve(res)
+              })
+              metaP = new Promise(resolve => call.on('metadata', resolve))
+            })
+          ).rejects.toThrow(`clientStream-${type}-error`)
+        })
+        test('Error data', () => {
+          expect(status.code).toBe(2)
+          expect(status.details).toBe(`clientStream-${type}-error`)
+        })
+        test('Trailing (status) metadata', () => {
+          expect(status.metadata.getMap().trailing).toBe(
+            'clientStream-trailing'
+          )
+          expect(status.metadata.getMap().onerror).toBe('clientStream-onerror')
+        })
+        test('Initial metadata', async () => {
+          expect((await metaP).getMap().initial).toEqual('clientStream')
+          expect((await metaP).getMap().onerror).toEqual('clientStream-onerror')
+        })
+      })
+    })
+  }
+  for (const type of ['sync', 'stream']) {
+    describe(`Bidi (${type} error)`, () => {
+      const client = new GreetingClient(
+        ADDR,
+        ChannelCredentials.createInsecure()
+      )
+      test('Caught error does not reach client', async () => {
+        const clientMeta = new Metadata()
+        clientMeta.set('catch', 'true')
+        clientMeta.set('type', type)
+        await new Promise<Hello>((resolve, reject) => {
+          const stream = client.bidi(clientMeta)
+          stream.on('data', hello => hello)
+          stream.on('end', () => resolve())
+          stream.on('error', (e: any) => (e.code === 1 ? resolve() : reject(e)))
+        })
+        expect(lastError.message).toMatch(new RegExp(`bidi-${type}-error`))
+      })
+      describe('Pass through rejects at client with correct status', () => {
+        const clientMeta = new Metadata()
+        clientMeta.set('type', type)
+        let status: StatusObject = null as any
+        let metaP: Promise<Metadata> = null as any
+        test('Throws', async () => {
+          await expect(
+            new Promise<Hello>((resolve, reject) => {
+              const stream = client.bidi(clientMeta)
+              stream.on('end', () => resolve())
+              metaP = new Promise(resolve => stream.on('metadata', resolve))
+              // Does not emit `status`: status object is in error on failure
+              stream.on('error', e => {
+                status = e as any
+                reject(e)
+              })
+            })
+          ).rejects.toThrow(`bidi-${type}-error`)
+        })
+        test('Error data', () => {
+          expect(status.code).toBe(2)
+          expect(status.details).toBe(`bidi-${type}-error`)
+        })
+        test('Trailing (status) metadata', () => {
+          expect(status.metadata.getMap().trailing).toBe('bidi-trailing')
+          expect(status.metadata.getMap().onerror).toBe('bidi-onerror')
+        })
+        test('Initial metadata', async () => {
+          expect((await metaP).getMap().initial).toEqual('bidi')
+          expect((await metaP).getMap().onerror).toEqual('bidi-onerror')
+        })
+      })
+    })
+  }
+})


### PR DESCRIPTION
- Add onError middleware
- Test error handling test scenarios (all types, stream/call stack errors, initial/trailing metadata)
- Add docs

This feature requires middelware support, thusly based of (blocked by) #1 