### PR TITLE
✨ Make next explicit flow control

### DIFF
--- a/src/lib/server/middleware/compose-middleware.ts
+++ b/src/lib/server/middleware/compose-middleware.ts
@@ -5,18 +5,8 @@ export const composeMiddleware = (middleware: Middleware[]): Middleware => {
     const dispatch = async (i: number): Promise<void> => {
       // TODO: Maybe throw / log on repeated next
       const fn = i === middleware.length ? next : middleware[i]
-      if (!fn) {
-        return
-      }
-      let nextCalled = false
-      await fn(call, () => {
-        nextCalled = true
-        return dispatch(i + 1)
-      })
-      // Dispatch should be called if there is still another middleware
-      if (!nextCalled && i !== middleware.length) {
-        return dispatch(i + 1)
-      }
+      if (!fn) return
+      await fn(call, () => dispatch(i + 1))
     }
     await dispatch(0)
   }

--- a/src/test/server/middleware/middleware.test.ts
+++ b/src/test/server/middleware/middleware.test.ts
@@ -21,18 +21,6 @@ describe('Middleware', () => {
       // expect correctly closed brackets without overlaps
       expect(acc).toBe(chain + chain.split('').reverse().join(''))
     })
-    test('Next implicit when missing', async () => {
-      const chain = 'abc'
-      let acc = ''
-      await composeMiddleware(
-        chain.split('').map(
-          (char): Middleware => (call, next) => {
-            acc += char
-          }
-        )
-      )(null as any, null as any)
-      expect(acc).toBe(chain)
-    })
     test('Error handling', async () => {
       let lastErr = ''
       const syncError: Middleware = (call, next) => {
@@ -40,8 +28,8 @@ describe('Middleware', () => {
       }
       const asyncError: Middleware = (call, next) =>
         Promise.reject(new Error('asyncError'))
-      const dud1: Middleware = jest.fn()
-      const dud2: Middleware = jest.fn()
+      const dud1: Middleware = jest.fn((call, next) => next())
+      const dud2: Middleware = jest.fn((call, next) => next())
       const catcher: Middleware = async (call, next) => {
         lastErr = await next().catch(e => e.message)
       }

--- a/src/test/server/middleware/on-error.test.ts
+++ b/src/test/server/middleware/on-error.test.ts
@@ -68,6 +68,7 @@ describe('Error handling', () => {
     app.use((call, next) => {
       call.initialMetadata.set('initial', call.type)
       call.trailingMetadata.set('trailing', `${call.type}-trailing`)
+      return next()
     })
     await app.start(ADDR, ServerCredentials.createInsecure())
   })

--- a/src/test/server/server.hello.test.ts
+++ b/src/test/server/server.hello.test.ts
@@ -29,10 +29,11 @@ describe('HelloService (boring, predictable and exhaustive)', () => {
   test('addService', () => {
     app.addService(GreetingService, {
       unary: [
-        call => {
+        (call, next) => {
           call.initialMetadata.set('type', 'initialUnary')
           call.initialMetadata.set('client', call.metadata.getMap().client)
           call.trailingMetadata.set('type', 'trailingUnary')
+          return next()
         },
         call => {
           call.response.setName(call.request?.getName() ?? '')


### PR DESCRIPTION
tldr; You must call `next` in middleware unless you want to stop the
exectution.

Previously, `next` was called implicitly by middleware composition, if
it was not called from the middleware itself.

While this behavior is convinient for some cases, it takes away the
possibility to skip the subsequent middleware execution for the purpose
of caching or any other early exit. This behavior is consistent with
other frameworks, like Express or Koa.