### PR TITLE
🏷️ Fix multiple handlers w/ServiceImplementation

### DIFF
--- a/src/lib/server/application.ts
+++ b/src/lib/server/application.ts
@@ -1,6 +1,6 @@
 import * as grpc from '@grpc/grpc-js'
 import { ChannelOptions } from '@grpc/grpc-js/build/src/channel-options'
-import { ServiceImplementation, Middleware } from './call'
+import { Middleware, ServiceImplementationExtended } from './call'
 import { stubToType } from '../call-types'
 import { bindAsync, tryShutdown } from '../misc/grpc-helpers'
 import { composeMiddleware } from './middleware/compose-middleware'
@@ -29,7 +29,7 @@ export class ProtoCat<Extension = {}> {
     T extends grpc.ServiceDefinition<grpc.UntypedServiceImplementation>
   >(
     serviceDefinition: T,
-    serviceImplementation: ServiceImplementation<T, Extension>
+    serviceImplementation: ServiceImplementationExtended<T, Extension>
   ) {
     for (const methodName in serviceDefinition) {
       // Path is FQN with namespace to avoid collisions

--- a/src/lib/server/call.ts
+++ b/src/lib/server/call.ts
@@ -79,8 +79,13 @@ type MethodDef2ServiceHandler<
 /** Create service handler type for whole client definition */
 export type ServiceImplementation<T, Extension = {}> = RemoveIdxSgn<
   {
-    [M in keyof T]:
-      | MethodDef2ServiceHandler<T[M], Extension>
-      | Array<MethodDef2ServiceHandler<T[M], Extension>>
+    [M in keyof T]: MethodDef2ServiceHandler<T[M], Extension>
   }
 >
+
+/** ServiceImplementation with array of middlewares */
+export type ServiceImplementationExtended<T, Extension = {}> = {
+  [M in keyof ServiceImplementation<T, Extension>]:
+    | ServiceImplementation<T, Extension>[M]
+    | Array<ServiceImplementation<T, Extension>[M]>
+}

--- a/src/test/server/call.test.ts
+++ b/src/test/server/call.test.ts
@@ -21,16 +21,23 @@ describe('Context extension types', () => {
   }
   app.use(mdw)
 
-  // Service definition inferred and explicit
   const unaryHandler: ServiceImplementation<
     IGreetingService,
     MyContext
   >['unary'] = call => call.uid
+
+  const serviceImpl: ServiceImplementation<IGreetingService, MyContext> = {
+    bidi: call => call.uid,
+    clientStream: call => call.uid,
+    serverStream: call => call.uid,
+    unary: call => call.uid,
+  }
+  // Service definition inferred and explicit
   app.addService(GreetingService, {
     bidi: call => call.uid,
-    unary: unaryHandler,
+    unary: [unaryHandler],
     serverStream: call => call.uid,
-    clientStream: call => call.uid,
+    clientStream: [call => call.uid, serviceImpl.clientStream],
   })
   test('Type check', jest.fn())
 })


### PR DESCRIPTION
Adding multiple handlers worked correctly for inlined handlers and type
helper with key access, but not with typed service implementation:

```typescript
const handler = ServiceImplementation<IService>['method']
const serviceImpl = ServiceImplementation<IService>

app.use(Service, {
  method: [
    call => call, // inline def: OK
    handler, // helper type direct: OK
    serviceImpl.method, // helper type, whole service: ERR
  ]
}
```

```
Type '((call: ProtoCatCall<...>, next: NextFn) => any) | ((call: ProtoCatCall<...>, next: NextFn) => any)[]'
    is not assignable to type '(call: ProtoCatCall<...>, next: NextFn) => any
```
TS cannot recognize in this context that `serviceImpl.method` is not an
array, which would create a nested array.

And it is correct assumption ofc. This could be solved with generics,
which would make the helper terribly complex to use (would require a
lambda), or by splitting the helper into standard versions with single
handlers and extended with possibility to have an array of handlers.

The latter was implemented and tested.