### PR TITLE
Add buffer cache support and middleware helper

### DIFF
--- a/src/lib/server/call.ts
+++ b/src/lib/server/call.ts
@@ -2,6 +2,7 @@ import * as grpc from '@grpc/grpc-js'
 import { RemoveIdxSgn, TypedOnData } from '../misc/type-helpers'
 import { CallType } from '../call-types'
 import { Message } from 'google-protobuf'
+import { Serialize } from '@grpc/grpc-js/build/src/make-client'
 
 /**
  * Extended gRPC call
@@ -36,6 +37,9 @@ export type ProtoCatCall<
   request?: Req
   /** Response message: only unary and client-stream */
   response?: Res
+  /** Response message: only unary and client-stream */
+  readonly responseSerialize: Serialize<Res>
+  bufferedResponse?: Buffer
 } & Extension &
   (Type extends CallType.Unary
     ? grpc.ServerUnaryCall<Req, Res> & {

--- a/src/lib/server/middleware/cache.ts
+++ b/src/lib/server/middleware/cache.ts
@@ -1,0 +1,31 @@
+import { Middleware, ProtoCatCall } from '../call'
+import { CallType } from '../../call-types'
+import { Message } from 'google-protobuf'
+
+export interface CacheImplementation<E = {}> {
+  hash: (
+    call: ProtoCatCall<E, Message, Message, CallType.Unary>
+  ) => Promise<string> | string
+  get: (key: string) => Promise<Buffer | undefined> | Buffer | undefined
+  set: (key: string, value: Buffer) => void
+}
+
+export const createCache = <E = {}>(
+  cache: CacheImplementation<E>
+): Middleware<E> => async (call, next) => {
+  if (call.type !== CallType.Unary) return next()
+  const key = await cache.hash(call)
+  if (!key) return next()
+  let cached = await cache.get(key)
+  if (!cached) {
+    // cache miss
+    // TODO callback?
+    await next()
+    cached = call.responseSerialize(call.response)
+    cache.set(key, cached)
+  } else {
+    // cache hit
+    // TODO callback?
+  }
+  call.bufferedResponse = cached
+}

--- a/src/lib/server/middleware/cache.ts
+++ b/src/lib/server/middleware/cache.ts
@@ -7,7 +7,11 @@ export interface CacheImplementation<E = {}> {
     call: ProtoCatCall<E, Message, Message, CallType.Unary>
   ) => Promise<string> | string
   get: (key: string) => Promise<Buffer | undefined> | Buffer | undefined
-  set: (key: string, value: Buffer) => void
+  set: (
+    key: string,
+    value: Buffer,
+    call: ProtoCatCall<E, Message, Message, CallType.Unary>
+  ) => void
 }
 
 export const createCache = <E = {}>(
@@ -27,7 +31,7 @@ export const createCache = <E = {}>(
     await cb?.(call, false, key)
     await next()
     cached = call.responseSerialize(call.response)
-    cache.set(key, cached)
+    cache.set(key, cached, call)
   } else {
     // cache hit
     await cb?.(call, true, key)

--- a/src/test/server/middleware/cache.test.ts
+++ b/src/test/server/middleware/cache.test.ts
@@ -1,0 +1,101 @@
+import { ProtoCat } from '../../..'
+import {
+  GreetingService,
+  GreetingClient,
+  IGreetingService,
+} from '../../../../dist/test/api/v1/hello_grpc_pb'
+import { ChannelCredentials } from '@grpc/grpc-js'
+import { Hello } from '../../../../dist/test/api/v1/hello_pb'
+import {
+  createCache,
+  CacheImplementation,
+} from '../../../lib/server/middleware/cache'
+import { performance } from 'perf_hooks'
+import { ServiceImplementation } from '../../../lib/server/call'
+
+const inf = <R>() => <T extends R>(_: T) => _
+const uniq = <T>(xs: T[]) => Array.from(new Set(xs))
+
+const ADDR = '0.0.0.0:3000'
+let c: Record<string, Buffer> = {}
+const cache = inf<CacheImplementation>()({
+  set: jest.fn((k, v) => {
+    c[k] = v
+  }),
+  get: jest.fn(k => c[k]),
+  hash: jest.fn(call => call.request.toArray().join('-')),
+})
+const unary = inf<ServiceImplementation<IGreetingService>['unary']>()(
+  jest.fn(call => {
+    call.response.setName(performance.now().toString())
+  })
+)
+describe('Cache middleware', () => {
+  const app = new ProtoCat()
+  afterAll(() => app.stop())
+  test('Setup', async () => {
+    app.addService(GreetingService, {
+      unary,
+      ...({} as any), // we skip def on non-unary
+    })
+    app.use(createCache(cache))
+    await app.start(ADDR)
+  })
+  describe('Caching', () => {
+    const client = new GreetingClient(ADDR, ChannelCredentials.createInsecure())
+    beforeEach(() => {
+      cache.set.mockClear()
+      cache.get.mockClear()
+      cache.hash.mockClear()
+      unary.mockClear()
+      c = {}
+    })
+    test('Cache miss, cache hit (invocation tests)', async () => {
+      const call = () =>
+        new Promise<Hello>((resolve, reject) => {
+          client.unary(new Hello().setName('Whiskers'), (err, res) =>
+            err ? reject(err) : resolve(res)
+          )
+        })
+      const res1 = await call()
+
+      expect(cache.hash).toBeCalledTimes(1)
+      expect(cache.get).toBeCalledTimes(1)
+      expect(cache.set).toBeCalledTimes(1)
+      expect(unary).toBeCalledTimes(1)
+
+      const res2 = await call()
+
+      expect(cache.hash).toBeCalledTimes(2)
+      expect(cache.get).toBeCalledTimes(2)
+      expect(cache.set).toBeCalledTimes(1)
+      expect(unary).toBeCalledTimes(1)
+      expect(res2.getName()).toBe(res1.getName())
+    })
+    test('Repeated requests (invocation tests)', async () => {
+      const requests = 'meeeeeoooweee!'.split('')
+      await Promise.all(
+        requests.map(
+          x =>
+            new Promise<Hello>((resolve, reject) => {
+              client.unary(new Hello().setName(x), (err, res) =>
+                err ? reject(err) : resolve(res)
+              )
+            })
+        )
+      )
+      // Hash called for each request
+      expect(cache.hash).toBeCalledTimes(requests.length)
+      // Cache got for each request
+      expect(cache.get).toBeCalledTimes(requests.length)
+      // Set only for misses
+      expect(cache.set).toBeCalledTimes(uniq(requests).length)
+      // Handler called only for misses
+      expect(unary).toBeCalledTimes(uniq(requests).length)
+      // Handler called only for unique request strings
+      expect(unary.mock.calls.map(([call]) => call.request.getName())).toEqual(
+        uniq(requests)
+      )
+    })
+  })
+})


### PR DESCRIPTION
 - Extend call interface to include `responseSerialize` (message instance to buffer) and `bufferedResponse` (buffer)
 - Update server's register function to provide updated `responseSerialize`, which skips serialization if the the response is buffer. Also uses `response` or `bufferedResponse` in callback respectively.
 - Add middleware creator with generic cache API
 - Add integration tests