### PR TITLE
⬆️ Upgrade dev deps and @grpc/grpc-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "cs:eclint:fix": "eclint fix '**/*'"
   },
   "dependencies": {
-    "@grpc/grpc-js": "1.1.5",
+    "@grpc/grpc-js": "^1.1.6",
     "@types/google-protobuf": "^3.7.3"
   },
   "devDependencies": {
@@ -53,10 +53,10 @@
     "husky": "^4.2.5",
     "jest": "^26.4.1",
     "lint-staged": "^10.2.11",
-    "prettier": "^2.0.5",
+    "prettier": "^2.1.2",
     "ts-jest": "^26.2.0",
-    "typedoc": "^0.18.0",
+    "typedoc": "^0.19.1",
     "typedoc-plugin-markdown": "^2.4.0",
-    "typescript": "^3.9.7"
+    "typescript": "^4.0.2"
   }
 }

--- a/src/test/client.test.ts
+++ b/src/test/client.test.ts
@@ -102,11 +102,11 @@ describe('Client', () => {
     ChannelCredentials.createInsecure(),
     {
       interceptors: [metadataInt, alInt],
-    } as any
-  ) // TODO: force cast https://github.com/grpc/grpc-node/issues/1558
+    }
+  )
   const nestedClient = createClient({ foo: GreetingClient }, ADDR, undefined, {
     interceptors: [metadataInt, alInt],
-  } as any)
+  })
   for (const [label, client] of [
     ['Single', singleClient],
     ['Multi', nestedClient.foo],


### PR DESCRIPTION
Upgrading grpc fixes a type bug with client options. Interceptors can
now be used without type casts.