### PR TITLE
Update command that generates stubs to also generate types

### DIFF
--- a/website/docs/wiki/stub-generation.md
+++ b/website/docs/wiki/stub-generation.md
@@ -31,6 +31,7 @@ And create stubs with the following command from installed `grpc-tools`:
 ```bash
 npx grpc_tools_node_protoc \
     --js_out=import_style=commonjs,binary:. \
+    --ts_out=generate_package_definition:. \
     --grpc_out=grpc_js:. \
     ./cat.proto
 ```

--- a/website/docs/wiki/stub-generation.md
+++ b/website/docs/wiki/stub-generation.md
@@ -37,8 +37,8 @@ npx grpc_tools_node_protoc \
 ```
 
 1. `--js_out` sets destination for JavaScript files for messages
+1. `--ts_out` generates the relevant `d.ts` files without needing to mention `grpc_tools_node_protoc_ts` explicitly
 1. `--grpc_out` sets destination for JavaScript files for gRPC services, sets to use `@grpc/grpc-js` implementation (instead of deprecated `grpc`)
-1. `grpc_tools_node_protoc_ts` does not have to be used explicitly, relevant `d.ts` files will be generated if the library is installed
 1. You can use `-I` for import path in your proto files in a larger project, see the `build:proto` task of ProtoCat, where stubs are compiled before tests
 
 The script should generate the following files:


### PR DESCRIPTION
When I follow I run the following command from [this section](https://proto.cat/docs/wiki/stub-generation), the `cat_pb.d.ts` and `cat_grpc_pb.d.ts` files aren’t generated.

```bash
npx grpc_tools_node_protoc \
    --js_out=import_style=commonjs,binary:. \
    --grpc_out=grpc_js:. \
    ./cat.proto
```

When I update it to also have this line, `--ts_out=generate_package_definition:. \`, it works as expected.